### PR TITLE
Adding logging for response error status codes and messages

### DIFF
--- a/tasks/app.js
+++ b/tasks/app.js
@@ -122,10 +122,12 @@ module.exports = function(grunt) {
 					}
 				}
 				else {
-					if (error)
+					if (error) {
 						grunt.log.error(error);
-					else
+					} else {
+						grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 						grunt.log.error(body);
+					}
 				}
 
 			}).auth(userid, passwd, true, token);

--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -89,10 +89,12 @@ module.exports = function(grunt) {
 					}
 				}
 				else {
-					if (error)
+					if (error) {
 						grunt.log.error(error);
-					else
+					} else {
+						grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 						grunt.log.error(body);
+					}
 				}
 
 			}).auth(userid, passwd, true, token);

--- a/tasks/flow_hook.js
+++ b/tasks/flow_hook.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
 				} else {
 					grunt.verbose.writeln(error);
 					grunt.log.error(error);
+					grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 				}
 				done_count++;
 				if (done_count == flow_hook_type.length) {

--- a/tasks/kvm_env.js
+++ b/tasks/kvm_env.js
@@ -42,6 +42,7 @@ module.exports = function(grunt) {
 						else
 						{
 							grunt.log.error(error);
+							grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 						}
 						done_count++;
 						if (done_count == kvms.length)
@@ -57,6 +58,7 @@ module.exports = function(grunt) {
 			else
 			{
 				grunt.log.error(error);
+				grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 			}
 		}.bind( {env_url: env_url, env: env})).auth(userid, passwd, true, token);
 		/*

--- a/tasks/kvm_org.js
+++ b/tasks/kvm_org.js
@@ -63,6 +63,7 @@ module.exports = function(grunt) {
 			else
 			{
 				grunt.log.error(error);
+				grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 			}
 		}).auth(userid, passwd, true, token);
 		/*

--- a/tasks/kvm_proxy.js
+++ b/tasks/kvm_proxy.js
@@ -51,6 +51,7 @@ module.exports = function(grunt) {
 									else
 									{
 										grunt.log.error(error);
+										grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 									}
 								}.bind( {proxy: proxy})).auth(userid, passwd, true, token);
 						    	// End kvm details
@@ -59,6 +60,7 @@ module.exports = function(grunt) {
 						else
 						{
 							grunt.log.error(error);
+							grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 						}
 						done_count++;
 						if (done_count == proxies.length)
@@ -73,6 +75,7 @@ module.exports = function(grunt) {
 			else
 			{
 				grunt.log.error(error);
+				grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 			}
 		}).auth(userid, passwd, true, token);
 		
@@ -148,6 +151,7 @@ module.exports = function(grunt) {
 				{
 					grunt.log.error("ERROR - from kvm URL : " + kvm_url );
 					grunt.log.error(body);
+					grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 				}
 
 			}.bind( {kvm_url: kvm_url}) ).auth(userid, passwd, true, token);	

--- a/tasks/product.js
+++ b/tasks/product.js
@@ -51,6 +51,7 @@ module.exports = function(grunt) {
 							{
 								grunt.verbose.writeln('Error Exporting Product ' + product_detail.name);
 								grunt.log.error(error);
+								grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 							}
 
 							done_count++;
@@ -69,6 +70,7 @@ module.exports = function(grunt) {
 			else
 			{
 				grunt.log.error(error);
+				grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 			}
 		}).auth(userid, passwd, true, token);
 		/*

--- a/tasks/proxy.js
+++ b/tasks/proxy.js
@@ -64,6 +64,7 @@ module.exports = function(grunt) {
 								grunt.verbose.writeln('Error exporting' + proxy_detail.name);
 							}
 							grunt.log.error(error);
+							grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 						}
 					}).auth(userid, passwd, true, token);
 			    	// End proxy details
@@ -72,6 +73,7 @@ module.exports = function(grunt) {
 			else
 			{
 				grunt.log.error(error);
+				grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 			}
 		}).auth(userid, passwd, true, token);
 		/*
@@ -217,6 +219,7 @@ module.exports = function(grunt) {
 				else
 				{
 					grunt.log.error(error);
+					grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 				}
 			}.bind( {proxy_url: proxy_url}) ).auth(userid, passwd, true, token);
 	});
@@ -249,6 +252,7 @@ module.exports = function(grunt) {
 							else
 							{
 								grunt.log.error(error);
+								grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 							}
 							done_count++;
 						  	if (done_count == proxies.length)
@@ -264,6 +268,7 @@ module.exports = function(grunt) {
 				else
 				{
 					grunt.log.error(error);
+					grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 				}
 			}).auth(userid, passwd, true, token);
 	});

--- a/tasks/report.js
+++ b/tasks/report.js
@@ -42,6 +42,7 @@ module.exports = function(grunt) {
 			else
 			{
 				grunt.log.error(error);
+				grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
 			}
 		}).auth(userid, passwd, true, token);
 		/*

--- a/tasks/shared_flow.js
+++ b/tasks/shared_flow.js
@@ -69,6 +69,7 @@ module.exports = function(grunt) {
                                     grunt.verbose.writeln('Error exporting: ' + response.statusCode + " URL: " + shared_flow_url);
                                 }
                                 grunt.log.error(error);
+                                grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
                             }
     					}).auth(userid, passwd, true, token);
     			    	// End shared flow details
@@ -227,6 +228,7 @@ module.exports = function(grunt) {
                 else
                 {
                     grunt.log.error(error);
+                    grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
                 }
             }.bind( {shared_flow_url: shared_flow_url}) ).auth(userid, passwd, true, token);
     });
@@ -259,6 +261,7 @@ module.exports = function(grunt) {
                             else
                             {
                                 grunt.log.error(error);
+                                grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
                             }
                             done_count++;
                               if (done_count == shared_flows.length)
@@ -274,6 +277,7 @@ module.exports = function(grunt) {
                 else
                 {
                     grunt.log.error(error);
+                    grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
                 }
             }).auth(userid, passwd, true, token);
     });

--- a/tasks/target_server.js
+++ b/tasks/target_server.js
@@ -65,6 +65,7 @@ module.exports = function(grunt) {
         }
       } else {
         grunt.log.error(error);
+        grunt.log.error("statusCode: " + response.statusCode + ", statusMessage: " + response.statusMessage);
       }
     }).auth(userid, passwd, true, token);
   });


### PR DESCRIPTION
When a response returned is an error the status code and message will now be logged to the console. This can help when troubleshooting issues, currently for some errors only the error object is being logged which can be null.